### PR TITLE
Get favorite by id with /favorites/:id endpoint

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -41,4 +41,22 @@ router.post('/', (request, response) => {
       });
 });
 
+router.get('/:id', (request, response) => {
+  let id = request.params.id
+  database('favorites').where('id', id)
+  .select('id', 'title', 'artistName', 'genre', 'rating')
+  .then(favorite => {
+    if (favorite.length) {
+      response.status(200).json(favorite[0]);
+    } else {
+      response.status(404).json({
+        error: `Could not find favorite with id ${id}`
+      });
+    }
+  })
+  .catch(error => {
+    response.status(500).json({ error });
+  });
+})
+
 module.exports = router;

--- a/tests/getFavoriteByID.spec.js
+++ b/tests/getFavoriteByID.spec.js
@@ -48,3 +48,11 @@ describe('Test the favorites endpoints', () => {
         expect(res.body.error).toBe("Could not find favorite with id 30");
     });
     
+    it('sad path, will return 500 if :id is anything other than an integer', async () => {
+      const res = await request(app)
+        .get("/api/v1/favorites/start")
+        expect(res.statusCode).toEqual(500);
+        expect(res.body).toHaveProperty("error");
+    });
+  })
+})

--- a/tests/getFavoriteByID.spec.js
+++ b/tests/getFavoriteByID.spec.js
@@ -39,3 +39,12 @@ describe('Test the favorites endpoints', () => {
         expect(res.body).toHaveProperty("rating");
         expect(res.body.rating).toBe(88);
     });
+
+    it('sad path, will return 404 if favorite is not found', async () => {
+      const res = await request(app)
+        .get("/api/v1/favorites/30")
+        expect(res.statusCode).toEqual(404);
+        expect(res.body).toHaveProperty("error");
+        expect(res.body.error).toBe("Could not find favorite with id 30");
+    });
+    

--- a/tests/getFavoriteByID.spec.js
+++ b/tests/getFavoriteByID.spec.js
@@ -1,0 +1,41 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Test the favorites endpoints', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table favorites cascade');
+
+    let favorite = {
+      id: 1,
+      title: 'We Will Rock You',
+      artistName: 'Queen',
+      genre: 'Awesome Rock',
+      rating: 88
+    };
+    await database('favorites').insert(favorite);
+  });
+
+  afterEach(() => {
+    database.raw('truncate table papers cascade');
+  });
+
+  describe('GET /api/v1/favorites/:id', () => {
+    it('happy path', async () => {
+      const res = await request(app)
+        .get("/api/v1/favorites/1")
+        expect(res.statusCode).toEqual(200);
+        expect(res.body).toHaveProperty("id");
+        expect(res.body).toHaveProperty("title");
+        expect(res.body.title).toBe("We Will Rock You");
+        expect(res.body).toHaveProperty("artistName");
+        expect(res.body.artistName).toBe("Queen");
+        expect(res.body).toHaveProperty("genre");
+        expect(res.body.genre).toBe("Awesome Rock");
+        expect(res.body).toHaveProperty("rating");
+        expect(res.body.rating).toBe(88);
+    });


### PR DESCRIPTION
### Fixes #8 

## Type of change 

- [ ] :beetle: Bug fix (non-breaking change which fixes an issue)
- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [x] :page_with_curl: This change requires a documentation update

## Summary of changes 
- Add `getFavoriteByID.spec.js` file in tests directory testing `GET /api/v1/favorites/:id` happy path, sad paths resulting in 404 and 500
- Add route `GET /api/v1/favorites/:id` to `favorites.js` file

## How Has This Been Tested?

- [x] :black_square_button: Integration testing 
- [ ] :white_square_button: Unit testing 

## Checklist:

- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes
