### PR TITLE
User can get all playlists with /playlists endpoint

### DIFF
--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -1,0 +1,16 @@
+var express = require('express');
+var router = express.Router();
+
+const fetch = require('node-fetch');
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../../../knexfile')[environment];
+const database = require('knex')(configuration);
+
+router.get('/', (request, response) => {
+  database('playlists').select()
+    .then(playlists => {
+      response.status(200).json(playlists)
+    }).catch(error => response.status(404).json({error: error}))
+});
+
+module.exports = router;

--- a/tests/playlists/getAllPlaylists.spec.js
+++ b/tests/playlists/getAllPlaylists.spec.js
@@ -1,0 +1,55 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Test the get playlists endpoint', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlists cascade')
+  });
+  afterEach(async () => {
+    await database.raw('truncate table playlists cascade');
+  });
+
+  describe('GET /api/v1/playlists', () => {
+   it('happy path', async () => {
+     let playlist_1 = {
+       title: 'Roadtrip!!!'
+     };
+     let playlist_2 = {
+       title: 'Study'
+     };
+     let playlist_3 = {
+       title: 'Lo-Fi'
+     };
+
+     await database('playlists').insert(playlist_1);
+     await database('playlists').insert(playlist_2);
+     await database('playlists').insert(playlist_3);
+
+     const res = await request(app)
+       .get("/api/v1/playlists")
+
+       expect(res.statusCode).toEqual(200);
+       expect(res.body.length).toEqual(3);
+       expect(res.body[0]).toHaveProperty("id");
+       expect(res.body[0]).toHaveProperty("title");
+       expect(res.body[0].title).toBe("Roadtrip!!!");
+       expect(res.body[2]).toHaveProperty("createdAt");
+       expect(res.body[2]).toHaveProperty("updatedAt");
+       expect(res.body[2].title).toBe("Lo-Fi");
+   })
+   describe('sad path for get playlists endpoint', () => {
+    it('will return 200 if no playlists', async () => {
+     const res = await request(app)
+       .get("/api/v1/playlists")
+
+       expect(res.statusCode).toEqual(200);
+       expect(res.body.length).toEqual(0);
+     });
+   });
+ })
+});


### PR DESCRIPTION
### Fixes #28 

## Type of change 

- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [x] :page_with_curl: This change requires a documentation update

## Summary of changes 
- Complete all playlists functionality
- Create happy path spec
- Create sad spec for returning empty array

## How Has This Been Tested?

- [x] :black_square_button: Integration testing 

## Checklist:

- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes
