### PR TITLE
Sad path: Update playlist by id with /playlists/:id endpoint

### DIFF
--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -33,22 +33,28 @@ router.put('/:id', (request, response) => {
   let id = request.params.id
   let title = request.body.title
 
-  database('playlists').where({id: id}).update({title: title})
-  .then(playlist => {
-    database('playlists').where('id', id)
-    .then(updatedPlaylist => {
-      response.status(200).json(updatedPlaylist[0])
-    })
-  })
-  .catch(error => {
-    response.status(404).json({
-      error: `Could not find playlist with id ${id}`
+  if (isNaN(id)) {
+    response.status(400).json({
+      error: "Please send a valid integer as the id parameter."
     });
-  })
-  .catch(error => {
-    console.log(error)
-    response.status(500).json({ error: "Please send a valid integer as an id parameter."});
-  });
+  } else {
+    database('playlists').where({id: id}).update({title: title})
+    .then(playlist => {
+      if (playlist === 1) {
+        database('playlists').where('id', id)
+        .then(updatedPlaylist => {
+          response.status(200).json(updatedPlaylist[0])
+        })
+        .catch(error => {
+          response.status(500).json({ error: "Could not update database"});
+        });
+      } else {
+        response.status(404).json({
+          error: `Could not find playlist with id ${id}`
+        });
+      }
+    })
+  }
 })
 
 router.delete('/:id', (request, response) => {

--- a/tests/playlists.spec.js
+++ b/tests/playlists.spec.js
@@ -106,7 +106,7 @@ describe('Test the get playlists endpoint', () => {
  });
 });
 
-describe('Test the deleteplaylist endpoint', () => {
+describe('Test the delete playlist endpoint', () => {
   beforeEach(async () => {
     await database.raw('truncate table playlists cascade');
 
@@ -190,3 +190,15 @@ describe('Test the update playlist endpoint', () => {
       expect(res.body.error).toBe("Could not find playlist with id 700");
     });
 
+    it('sad path, will return 400 if :id is anything other than an integer', async () => {
+      const res = await request(app)
+        .put("/api/v1/playlists/bob")
+        .send({
+          title: "Workout Jamz",
+        });
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body).toHaveProperty("error");
+      expect(res.body.error).toBe("Please send a valid integer as the id parameter.");
+    });
+});

--- a/tests/playlists.spec.js
+++ b/tests/playlists.spec.js
@@ -177,3 +177,16 @@ describe('Test the update playlist endpoint', () => {
       expect(res.body).toHaveProperty("updatedAt");
     });
   });
+
+    it('sad path, will return 404 if playlist is not found', async () => {
+      const res = await request(app)
+        .put("/api/v1/playlists/700")
+        .send({
+          title: "Workout Jamz",
+        });
+
+      expect(res.statusCode).toEqual(404);
+      expect(res.body).toHaveProperty("error");
+      expect(res.body.error).toBe("Could not find playlist with id 700");
+    });
+


### PR DESCRIPTION
### Fixes #30 

## Type of change 

- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [x] :page_with_curl: This change requires a documentation update

## Summary of changes 
- Add 404 and 400 sad paths for `PUT /playlists/:id` route
- Add sad path tests to `playlists.spec.js`

## How Has This Been Tested?

- [x] :black_square_button: Integration testing 

## Checklist:

- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing integration tests pass locally with my changes
