### PR TITLE
Sad path: 422 and 409 error handling for update playlist with id /playlists/:id endpoint

### DIFF
--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -37,6 +37,10 @@ router.put('/:id', (request, response) => {
     response.status(400).json({
       error: "Please send a valid integer as the id parameter."
     });
+  } else if (!title) {
+    response.status(422).json({
+      error: "Playlist not updated, please enter a title."
+    });
   } else {
     database('playlists').where({id: id}).update({title: title})
     .then(playlist => {
@@ -46,14 +50,18 @@ router.put('/:id', (request, response) => {
           response.status(200).json(updatedPlaylist[0])
         })
         .catch(error => {
-          response.status(500).json({ error: "Could not update database"});
-        });
+          console.log(error)
+          response.status(500).send()
+        })
       } else {
         response.status(404).json({
           error: `Could not find playlist with id ${id}`
         });
       }
     })
+    .catch(error => {
+      response.status(409).json({ error: "Title must be unique!"});
+    });
   }
 })
 

--- a/tests/playlists.spec.js
+++ b/tests/playlists.spec.js
@@ -201,4 +201,15 @@ describe('Test the update playlist endpoint', () => {
       expect(res.body).toHaveProperty("error");
       expect(res.body.error).toBe("Please send a valid integer as the id parameter.");
     });
+
+    it('sad path, will return 422 if title is not sent in request', async () => {
+      const res = await request(app)
+        .put("/api/v1/playlists/4")
+        .send({})
+
+      expect(res.statusCode).toEqual(422);
+      expect(res.body).toHaveProperty("error");
+      expect(res.body.error).toBe("Playlist not updated, please enter a title.");
+    });
+
 });

--- a/tests/playlists.spec.js
+++ b/tests/playlists.spec.js
@@ -153,7 +153,11 @@ describe('Test the update playlist endpoint', () => {
       id: 4,
       title: 'Pump up Jamz'
     };
+    let playlist_2 = {
+      title: 'Study'
+    };
     await database('playlists').insert(playlist);
+    await database('playlists').insert(playlist_2);
   });
 
   afterEach(() => {
@@ -212,4 +216,15 @@ describe('Test the update playlist endpoint', () => {
       expect(res.body.error).toBe("Playlist not updated, please enter a title.");
     });
 
+    it('sad path, will return 409 if title is not unique', async () => {
+      const res = await request(app)
+        .put("/api/v1/playlists/4")
+        .send({
+          title: "Study"
+        })
+
+      expect(res.statusCode).toEqual(409);
+      expect(res.body).toHaveProperty("error");
+      expect(res.body.error).toBe("Title must be unique!");
+    });
 });


### PR DESCRIPTION
### Fixes #30 

## Type of change 

- [x] :beetle: Bug fix (non-breaking change which fixes an issue)
- [x] :page_with_curl: This change requires a documentation update

## Summary of changes 
- Add sad path specs for handling 422 and 409 errors
- Add conditionals to handle  422 and 409 errors

## How Has This Been Tested?

- [x] :black_square_button: Integration testing 

## Checklist:

- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing integration tests pass locally with my changes
