### PR TITLE
Refactor all 500 status codes to not send json

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -62,7 +62,8 @@ router.get('/:id', (request, response) => {
     }
   })
   .catch(error => {
-    response.status(500).json({ error });
+    console.log(error)
+    response.status(500).send();
   });
 })
 
@@ -79,7 +80,8 @@ router.delete('/:id', (request, response) => {
     }
   })
   .catch(error => {
-    response.status(500).json({ error });
+    console.log(error)
+    response.status(500).send();
   });
 })
 

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -78,7 +78,8 @@ router.delete('/:id', (request, response) => {
     }
   })
   .catch(error => {
-    response.status(500).json({ error });
+    console.log(error)
+    response.status(500).send();
   });
 })
 

--- a/tests/favorites.spec.js
+++ b/tests/favorites.spec.js
@@ -282,7 +282,6 @@ describe('Test the get specific favorite endpoint', () => {
       const res = await request(app)
         .get("/api/v1/favorites/start")
         expect(res.statusCode).toEqual(500);
-        expect(res.body).toHaveProperty("error");
     });
   });
 });
@@ -324,7 +323,6 @@ describe('Test the delete favorite endpoint', () => {
       const res = await request(app)
         .delete("/api/v1/favorites/start")
         expect(res.statusCode).toEqual(500);
-        expect(res.body).toHaveProperty("error");
     });
   });
 });

--- a/tests/playlists.spec.js
+++ b/tests/playlists.spec.js
@@ -140,7 +140,6 @@ describe('Test the delete playlist endpoint', () => {
       const res = await request(app)
         .delete("/api/v1/playlists/start")
         expect(res.statusCode).toEqual(500);
-        expect(res.body).toHaveProperty("error");
     });
   });
 });


### PR DESCRIPTION
### Fixes #42 
 
## Type of change 

- [x] :beetle: Bug fix (non-breaking change which fixes an issue)

## Summary of changes 

- Refactor favorites endpoint to console log error on 500 status
- Refactor playlists endpoint to console log error on 500 status

## How Has This Been Tested?

- [x] :black_square_button: Integration testing 

## Checklist:

- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes
