### PR TITLE
Create many to many migration between favorites and playlists

### DIFF
--- a/db/migrations/20200211144102_playlist-favorites.js
+++ b/db/migrations/20200211144102_playlist-favorites.js
@@ -1,0 +1,23 @@
+
+exports.up = function(knex) {
+  return Promise.all([
+    knex.schema.createTable('playlists_favorites',
+     function(table) {
+      table.increments('id').primary();
+      table.integer('playlist_id').unsigned().notNullable()
+      table.foreign('playlist_id').references('id').inTable('playlists');
+
+      table.integer('favorite_id').unsigned().notNullable()
+      table.foreign('favorite_id').references('id').inTable('favorites');
+
+      table.timestamps(true, true);
+      })
+  ])
+};
+
+
+exports.down = function(knex) {
+  return Promise.all([
+    knex.schema.dropTable('playlists_favorites')
+  ])
+};

--- a/db/migrations/20200211151742_rename-play-fav-timestamps.js
+++ b/db/migrations/20200211151742_rename-play-fav-timestamps.js
@@ -1,0 +1,20 @@
+
+exports.up = function(knex) {
+  return Promise.all([
+    knex.schema.table('playlists_favorites',
+      function(table) {
+        table.renameColumn('created_at', 'createdAt');
+        table.renameColumn('updated_at', 'updatedAt');
+      })
+  ])
+};
+
+exports.down = function(knex) {
+  return Promise.all([
+    knex.schema.table('playlists_favorites',
+      function(table) {
+        table.renameColumn('createdAt', 'created_at');
+        table.renameColumn('updatedAt', 'updated_at');
+      })
+  ])
+};


### PR DESCRIPTION
### Fixes #49 

## Type of change 

- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [x] :page_with_curl: This change requires a documentation update

## Summary of changes 

- Create migration for playlists/favorites joins table
- Rename created_at and updated_at properties

## Checklist:

- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :100: New and existing unit tests pass locally with my changes
