### PR TITLE
Get all favorites with playlist ls

### DIFF
--- a/tests/playlistFavorites.spec.js
+++ b/tests/playlistFavorites.spec.js
@@ -51,3 +51,74 @@ describe('Test it can add favorites to playlists_favorites endpoint', () => {
     })
   })
 })
+
+describe('Test it can get all favorites for a playlist with playlists_favorites endpoint', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlists_favorites cascade')
+    await database.raw('truncate table playlists cascade')
+    await database.raw('truncate table favorites cascade')
+  });
+  afterEach(async () => {
+    await database.raw('truncate table playlists_favorites cascade');
+    await database.raw('truncate table playlists cascade');
+    await database.raw('truncate table favorites cascade');
+  });
+
+  describe('GET /api/v1/playlists/:id/favorites', () => {
+    it('happy path', async () => {
+      let playlist = {
+        id: 9,
+        title: 'Roadtrip'
+      }
+      let favorite_1 = {
+        id: 30,
+        title: "Bohemian Rhapsody",
+        artistName: "Queen",
+        genre: "Awesome Rock",
+        rating: 80
+      }
+      let favorite_2 = {
+        id: 49,
+        title: "You Shook Me All Night Long",
+        artistName: "ACDC",
+        genre: "Rock",
+        rating: 75
+      }
+      let favorite_3 = {
+        id: 50,
+        title: "New Song",
+        artistName: "ACDC",
+        genre: "Rock",
+        rating: 75
+      }
+      let playlistFavorite_1 = {
+        playlist_id: 9,
+        favorite_id: 30
+      }
+      let playlistFavorite_2 = {
+        playlist_id: 9,
+        favorite_id: 49
+      }
+      await database('playlists').insert(playlist)
+      await database('favorites').insert(favorite_1)
+      await database('favorites').insert(favorite_2)
+      await database('favorites').insert(favorite_3)
+      await database('playlists_favorites').insert(playlistFavorite_1)
+      await database('playlists_favorites').insert(playlistFavorite_2)
+
+      const res = await request(app)
+        .get('/api/v1/playlists/9/favorites')
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toHaveProperty("id");
+      expect(res.body).toHaveProperty("songCount");
+      expect(res.body.songCount).toBe(2);
+      expect(res.body).toHaveProperty("songAvgRating");
+      expect(res.body.songAvgRating).toBe(77.5);
+      expect(res.body).toHaveProperty("favorites");
+      expect(res.body.favorites.length).toBe(2);
+      expect(res.body).toHaveProperty("createdAt");
+      expect(res.body).toHaveProperty("updatedAt");
+    })
+  })
+})


### PR DESCRIPTION
### Fixes #52

## Type of change 

- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [x] :page_with_curl: This change requires a documentation update

## Summary of changes 
- Add spec for happy path `GET /playlists/:id/favorites/:id`
- Add route for `GET /playlists/:id/favorites/:id`

## How Has This Been Tested?

- [x] :black_square_button: Integration testing 

## Checklist:

- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes
