### PR TITLE
User can delete a specific playlist with /playlists/:id/favorites/:id endpoint

### DIFF
--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -116,6 +116,17 @@ router.get('/:playlistId/favorites', (req, res) => {
          });
 })
 
+router.delete('/:playlistId/favorites/:favoriteId', (request, response) => {
+  let playlistId = request.params.playlistId
+  let favoriteId = request.params.favoriteId
+  database('playlists_favorites').where({playlist_id: playlistId, favorite_id: favoriteId}).del()
+  .then(favorite => {
+    if (favorite > 0) {
+      response.status(204).send();
+    }
+  })
+});
+
 router.use('/:playlistId/favorites', function(req, res, next) {
   req.playlistId = req.params.playlistId;
   next()

--- a/tests/playlistFavorites.spec.js
+++ b/tests/playlistFavorites.spec.js
@@ -122,3 +122,48 @@ describe('Test it can get all favorites for a playlist with playlists_favorites 
     })
   })
 })
+
+describe('Test the delete playlist endpoint', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlists cascade');
+
+    let playlist = {
+      id: 1,
+      title: 'Roadtrip!!'
+    };
+    let favorite_1 = {
+      id: 45,
+      title: "Bohemian Rhapsody",
+      artistName: "Queen",
+      genre: "Awesome Rock",
+      rating: 80
+    };
+    let favorite_2 = {
+      id: 49,
+      title: "You Shook Me All Night Long",
+      artistName: "ACDC",
+      genre: "Rock",
+      rating: 75
+    }
+    let playlistFavorite_1 = {
+      playlist_id: 1,
+      favorite_id: 45
+    }
+    await database('playlists').insert(playlist);
+    await database('favorites').insert(favorite_1);
+    await database('favorites').insert(favorite_2);
+    await database('playlists_favorites').insert(playlistFavorite_1);
+  });
+
+  afterEach(() => {
+    database.raw('truncate table playlists cascade');
+  });
+
+  describe('DELETE /api/v1/playlists/:id/favorites/:id', () => {
+    it('happy path', async () => {
+      const res = await request(app)
+        .delete("/api/v1/playlists/1/favorites/45")
+        expect(res.statusCode).toEqual(204);
+    });
+  });
+});


### PR DESCRIPTION
### Fixes #53 

## Type of change 

- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [x] :page_with_curl: This change requires a documentation update

## Summary of changes 

- Add happy path spec for DELETE /playlists/:id/favorites/:id
- Complete functionality for DELETE /playlists/:id/favorites/:id

## How Has This Been Tested?

- [x] :white_square_button: Unit testing 

## Checklist:

- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes
