### PR TITLE
Sad path: User can delete a favorite from a playlist with /playlists/:id/favorites/:id endpoint

### DIFF
--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -119,13 +119,34 @@ router.get('/:playlistId/favorites', (req, res) => {
 router.delete('/:playlistId/favorites/:favoriteId', (request, response) => {
   let playlistId = request.params.playlistId
   let favoriteId = request.params.favoriteId
-  database('playlists_favorites').where({playlist_id: playlistId, favorite_id: favoriteId}).del()
-  .then(favorite => {
-    if (favorite > 0) {
-      response.status(204).send();
-    }
+
+  database('playlists_favorites').where({playlist_id: playlistId})
+  .then(playlists => {
+    if (playlists.length === 0) {
+      response.status(404).json({error: `Could not find playlist with id ${playlistId}`})
+    } else {
+      database('playlists_favorites').where({favorite_id: favoriteId})
+      .then(favorites => {
+        if (favorites.length === 0) {
+          response.status(404).json({error: `Could not find favorite with id ${favoriteId}`})
+        } else {
+            database('playlists_favorites').where({playlist_id: playlistId, favorite_id: favoriteId}).del()
+            .then(favorite => {
+              if (favorite > 0) {
+                response.status(204).send();
+              }
+            })
+            .catch(error =>  {
+              console.log(error)
+              response.status(500).send();
+            })
+          }
+        })
+      }
+    })
   })
-});
+
+
 
 router.use('/:playlistId/favorites', function(req, res, next) {
   req.playlistId = req.params.playlistId;

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -123,12 +123,12 @@ router.delete('/:playlistId/favorites/:favoriteId', (request, response) => {
   database('playlists_favorites').where({playlist_id: playlistId})
   .then(playlists => {
     if (playlists.length === 0) {
-      response.status(404).json({error: `Could not find playlist with id ${playlistId}`})
+      response.status(404).json({error: `Could not find playlist with id ${playlistId}. Please make sure the id is an integer and greater than 0.`})
     } else {
       database('playlists_favorites').where({favorite_id: favoriteId})
       .then(favorites => {
         if (favorites.length === 0) {
-          response.status(404).json({error: `Could not find favorite with id ${favoriteId}`})
+          response.status(404).json({error: `Could not find favorite with id ${favoriteId}. Please make sure the id is an integer and greater than 0.`})
         } else {
             database('playlists_favorites').where({playlist_id: playlistId, favorite_id: favoriteId}).del()
             .then(favorite => {

--- a/tests/playlistFavorites.spec.js
+++ b/tests/playlistFavorites.spec.js
@@ -126,6 +126,8 @@ describe('Test it can get all favorites for a playlist with playlists_favorites 
 describe('Test the delete playlist endpoint', () => {
   beforeEach(async () => {
     await database.raw('truncate table playlists cascade');
+    await database.raw('truncate table playlists_favorites cascade');
+    await database.raw('truncate table favorites cascade');
 
     let playlist = {
       id: 1,
@@ -157,6 +159,8 @@ describe('Test the delete playlist endpoint', () => {
 
   afterEach(() => {
     database.raw('truncate table playlists cascade');
+    database.raw('truncate table playlists_favorites cascade');
+    database.raw('truncate table favorites cascade');
   });
 
   describe('DELETE /api/v1/playlists/:id/favorites/:id', () => {

--- a/tests/playlistFavorites.spec.js
+++ b/tests/playlistFavorites.spec.js
@@ -176,7 +176,7 @@ describe('Test the delete playlist endpoint', () => {
 
       expect(res.statusCode).toEqual(404);
       expect(res.body).toHaveProperty("error");
-      expect(res.body.error).toBe("Could not find favorite with id 789");
+      expect(res.body.error).toBe("Could not find favorite with id 789. Please make sure the id is an integer and greater than 0.");
     });
 
     it('sad path, will return 404 if playlist ID is not found', async () => {
@@ -185,7 +185,7 @@ describe('Test the delete playlist endpoint', () => {
 
       expect(res.statusCode).toEqual(404);
       expect(res.body).toHaveProperty("error");
-      expect(res.body.error).toBe("Could not find playlist with id 789");
+      expect(res.body.error).toBe("Could not find playlist with id 789. Please make sure the id is an integer and greater than 0.");
     });
   });
 });

--- a/tests/playlistFavorites.spec.js
+++ b/tests/playlistFavorites.spec.js
@@ -169,5 +169,23 @@ describe('Test the delete playlist endpoint', () => {
         .delete("/api/v1/playlists/1/favorites/45")
         expect(res.statusCode).toEqual(204);
     });
+
+    it('sad path, will return 404 if favorite ID is not found', async () => {
+      const res = await request(app)
+        .delete("/api/v1/playlists/1/favorites/789")
+
+      expect(res.statusCode).toEqual(404);
+      expect(res.body).toHaveProperty("error");
+      expect(res.body.error).toBe("Could not find favorite with id 789");
+    });
+
+    it('sad path, will return 404 if playlist ID is not found', async () => {
+      const res = await request(app)
+        .delete("/api/v1/playlists/789/favorites/45")
+
+      expect(res.statusCode).toEqual(404);
+      expect(res.body).toHaveProperty("error");
+      expect(res.body.error).toBe("Could not find playlist with id 789");
+    });
   });
 });


### PR DESCRIPTION
### Fixes #54 

## Type of change 

- [x] :beetle: Bug fix (non-breaking change which fixes an issue)
- [x] :page_with_curl: This change requires a documentation update

## Summary of changes 
- Add 404 sad path spec for `DELETE /playlists/:id/favorites/:id `
- Add implementation of 404 sad path for `DELETE /playlists/:id/favorites/:id` route

## How Has This Been Tested?

- [x] :black_square_button: Integration testing 

## Checklist:

- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented on my code, particularly in hard-to-understand areas
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes
