### PR TITLE
Sad path: User can add favorite to playlist with  /playlists/:id/favorites/:id endpoint

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -89,11 +89,19 @@ router.post('/:favoriteId', async (req, res) => {
   var playlist = await database('playlists').where({id: req.params.playlistId}).first()
   var favorite = await database('favorites').where({id: req.params.favoriteId}).first()
 
-  database('playlists_favorites').insert({playlist_id: req.params.playlistId, favorite_id: req.params.favoriteId}, "id")
+  if (playlist === undefined) {
+    res.status(404).json({ error: `Could not find playlist with id ${req.params.playlistId}. Please make sure the id is an integer and greater than 0.` })
+  } else if (favorite === undefined) {
+    res.status(404).json({ error: `Could not find favorite with id ${req.params.favoriteId}. Please make sure the id is an integer and greater than 0.` })
+  } else {
+    database('playlists_favorites').insert({playlist_id: req.params.playlistId, favorite_id: req.params.favoriteId}, "id")
     .then(newFavorite => {
       res.status(201).json({Success: `${favorite.title} has been added to ${playlist.title}!`})
-    });
+    })
+    .catch(error => {
+      res.status(400).json({ error: 'Unable to add favorite to playlist.'})
+    })
+  }
 });
-
 
 module.exports = router;

--- a/tests/playlistFavorites.spec.js
+++ b/tests/playlistFavorites.spec.js
@@ -49,6 +49,66 @@ describe('Test it can add favorites to playlists_favorites endpoint', () => {
       expect(res.body).toHaveProperty('Success')
       expect(res.body.Success).toBe(`${favorite_1.title} has been added to ${playlist.title}!`)
     })
+    it('sad path, will return 404 if favorite ID is not found', async () => {
+      let playlist = {
+        id: 5,
+        title: 'Roadtrip'
+      }
+
+      let favorite_1 = {
+        id: 75,
+        title: "Bohemian Rhapsody",
+        artistName: "Queen",
+        genre: "Awesome Rock",
+        rating: 80
+      }
+      let favorite_2 = {
+        id: 80,
+        title: "You Shook Me All Night Long",
+        artistName: "ACDC",
+        genre: "Rock",
+        rating: 75
+      }
+      await database('playlists').insert(playlist)
+      await database('favorites').insert(favorite_1)
+      await database('favorites').insert(favorite_2)
+      const res = await request(app)
+        .post('/api/v1/playlists/5/favorites/-75')
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body).toHaveProperty('error')
+      expect(res.body.error).toBe(`Could not find favorite with id -75. Please make sure the id is an integer and greater than 0.`)
+    })
+    it('sad path, will return 404 if newPlaylist ID is not found', async () => {
+      let playlist = {
+        id: 5,
+        title: 'Roadtrip'
+      }
+
+      let favorite_1 = {
+        id: 75,
+        title: "Bohemian Rhapsody",
+        artistName: "Queen",
+        genre: "Awesome Rock",
+        rating: 80
+      }
+      let favorite_2 = {
+        id: 80,
+        title: "You Shook Me All Night Long",
+        artistName: "ACDC",
+        genre: "Rock",
+        rating: 75
+      }
+      await database('playlists').insert(playlist)
+      await database('favorites').insert(favorite_1)
+      await database('favorites').insert(favorite_2)
+      const res = await request(app)
+        .post('/api/v1/playlists/-5/favorites/75')
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body).toHaveProperty('error')
+      expect(res.body.error).toBe(`Could not find playlist with id -5. Please make sure the id is an integer and greater than 0.`)
+    })
   })
 })
 


### PR DESCRIPTION
### Fixes #51 

## Type of change 

- [x] :beetle: Bug fix (non-breaking change which fixes an issue)
- [x] :page_with_curl: This change requires a documentation update

## Summary of changes 
- Add 404 spec for `POST /playlists/:id/favorites/:id`
- Add functionality for 404 error for `POST /playlists/:id/favorites/:id`

## How Has This Been Tested?

- [x] :black_square_button: Integration testing 

## Checklist:

- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented on my code, particularly in hard-to-understand areas
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :100: New and existing unit tests pass locally with my changes
