### PR TITLE
Add user friendly error message when params is not an integer

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -50,21 +50,25 @@ router.get('/', (request, response) => {
 
 router.get('/:id', (request, response) => {
   let id = request.params.id
-  database('favorites').where('id', id)
-  .select('id', 'title', 'artistName', 'genre', 'rating')
-  .then(favorite => {
-    if (favorite.length) {
-      response.status(200).json(favorite[0]);
-    } else {
-      response.status(404).json({
-        error: `Could not find favorite with id ${id}`
-      });
-    }
-  })
-  .catch(error => {
-    console.log(error)
-    response.status(500).send();
-  });
+  if (isNaN(id)) {
+    response.status(404).json({ error: 'Please send in a parameter that is an integer and greater than 0' })
+  } else {
+    database('favorites').where('id', id)
+    .select('id', 'title', 'artistName', 'genre', 'rating')
+    .then(favorite => {
+      if (favorite.length) {
+        response.status(200).json(favorite[0]);
+      } else {
+        response.status(404).json({
+          error: `Could not find favorite with id ${id}`
+        });
+      }
+    })
+    .catch(error => {
+      console.log(error)
+      response.status(500).send();
+    });
+  }
 })
 
 router.delete('/:id', (request, response) => {

--- a/tests/favorites.spec.js
+++ b/tests/favorites.spec.js
@@ -281,7 +281,7 @@ describe('Test the get specific favorite endpoint', () => {
     it('sad path, will return 500 if :id is anything other than an integer', async () => {
       const res = await request(app)
         .get("/api/v1/favorites/start")
-        expect(res.statusCode).toEqual(500);
+        expect(res.statusCode).toEqual(404);
     });
   });
 });


### PR DESCRIPTION
### Fixes #23 

## Type of change 

- [x] :beetle: Bug fix (non-breaking change which fixes an issue)

## Summary of changes 

- Add sad path for favorite id thats not a number

## How Has This Been Tested?

- [x] :white_square_button: Unit testing 

## Checklist:

- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes
